### PR TITLE
Add logic to modify UI based on USB policy flag

### DIFF
--- a/dist/script/models/hostModel.js
+++ b/dist/script/models/hostModel.js
@@ -60,6 +60,7 @@ XenClient.UI.HostModel = function() {
     this.policy_update = true; // Hide OTA URL stuffs
     this.policy_modify_settings = true; // Hide platform settings
     this.policy_modify_services = true; // Hide platform services button
+    this.policy_modify_usb_settings = true; // Disable USB settings
     this.policy_modify_vm_advanced = true; // Hide all VM advanced tabs
     this.policy_screen_lock = true; // Disable setting screen lock details
     this.configure_reboot_save = false;
@@ -159,6 +160,7 @@ XenClient.UI.HostModel = function() {
         ["supported_languages",                 interfaces.ui],
         ["policy_modify_settings",              interfaces.ui,      "modify-settings"],
         ["policy_modify_services",              interfaces.ui,      "modify-services"],
+        ["policy_modify_usb_settings",          interfaces.ui,      "modify-usb-settings"],
         ["policy_modify_vm_advanced",           interfaces.ui,      "modify-advanced-vm-settings"],
         ["available_isos",                      interfaces.host.list_isos],
         ["available_gpus",                      interfaces.host.list_gpu_devices],

--- a/dist/script/models/vmModel.js
+++ b/dist/script/models/vmModel.js
@@ -921,7 +921,7 @@ XenClient.UI.VMModel = function(vm_path) {
     };
 
     this.canAddDevice = function() {
-        if (!self.usb_enabled || self.getState() != XenConstants.VMStates.VM_RUNNING) {
+        if (!self.usb_enabled || self.getState() != XenConstants.VMStates.VM_RUNNING || !XUICache.Host.policy_modify_usb_settings) {
             return false;
         }
         if (self.hosting_type == XenConstants.VMTypes.ICA) {

--- a/widgets/xenclient/Devices.js
+++ b/widgets/xenclient/Devices.js
@@ -170,16 +170,28 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
     _setControls: function(deviceID, prefix) {
         var check = dijit.byId(prefix + "_check_" + deviceID);
         var select = dijit.byId(prefix + "_select_" + deviceID);
+        var name = dijit.byId(prefix + "_name_" + deviceID);
 
         if (check && select) {
-            if (select.value == "") {
-                this._setEnabled(check, false);
-                check.set("checked", false);
+            if (prefix != "usb" || this.host.policy_modify_usb_settings){
+                if (select.value == "") {
+                    this._setEnabled(check, false);
+                    check.set("checked", false);
+                } else {
+                    this._setEnabled(check, true);
+                    this._setEnabled(select, !check.checked);
+                }
             } else {
-                this._setEnabled(check, true);
-                this._setEnabled(select, !check.checked);
+                this._setEnabled(check, false);
+                this._setEnabled(select, false);
+            }
+        } 
+        if (name) {
+            if (prefix == "usb" && !this.host.policy_modify_usb_settings){
+                this._setEnabled(name, false);
             }
         }
+         
     },
 
     _messageHandler: function(message) {

--- a/widgets/xenclient/VMDetails.js
+++ b/widgets/xenclient/VMDetails.js
@@ -345,11 +345,13 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
     },
 
     _descendantAction: function(action) {
-        dojo.forEach(this.getDescendants(), function(widget){
+        dojo.forEach(this.getDescendants(), dojo.hitch(this, function(widget){
             if(widget[action] && typeof(widget[action]) == "function") {
-                widget[action]();
+                if(widget.name != "connectedDevices" || this.vm.canAddDevice()){
+                    widget[action]();
+                }
             }
-        });
+        }));
     },
 
     _bindDijit: function() {
@@ -401,6 +403,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
         this._setDisplay(this.deleteAction, this.vm.deleteVisible());
         this._setEnabled(".nicButton", this.vm.canEditNics());
         this._setEnabled(".diskButton", this.vm.canEditDisk());
+        this._setEnabled(".usbButton", this.vm.canAddDevice());
         this._setEnabled(".pci", this.vm.canModifyPCI());
     },
 
@@ -555,7 +558,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
     },
 
     _updateTooltips: function() {
-        this.addAction.domNode.title = !this.vm.usb_enabled ? this.USB_DISABLED : (this.vm.canAddDevice()) ? "" : this.ADD_DEVICE_STATUS;
+        this.addAction.domNode.title = !this.vm.usb_enabled ? this.USB_DISABLED : (this.vm.canAddDevice()) ? "" : this.vm.getState() != XenConstants.VMStates.VM_RUNNING || !this.vm.tools_installed ? this.ADD_DEVICE_STATUS : this.USB_HOST_DISABLED;
         this.deleteAction.domNode.title = (this.vm.canDelete()) ? "" : this.DELETE_VM_STATUS;
     },
 

--- a/widgets/xenclient/nls/VMDetails.js
+++ b/widgets/xenclient/nls/VMDetails.js
@@ -174,6 +174,7 @@
     DELETE_VM_STATUS: "You can only delete a virtual machine when its state is off or hibernated",
     FORCE_UPDATE: "Error force updating the VM",
     USB_DISABLED: "Unable to add a device as device management has been disabled for this VM",
+    USB_HOST_DISABLED: "Unable to add device due to system policy",
     LOADING: "Loading...",
     DISKS: "Disks",
     DISK_TH: "Disk",

--- a/widgets/xenclient/templates/VMDetails.html
+++ b/widgets/xenclient/templates/VMDetails.html
@@ -110,7 +110,7 @@
                                     <label for="check_%dev_id%">${ALWAYS_USE}</label>
                                 </td>
                                 <td>
-                                    <button templateType="citrix.common.Button" dojoAttachEvent="onClick: onUsbDetach">${DISCONNECT}</button>
+                                    <button class="usbButton" templateType="citrix.common.Button" dojoAttachEvent="onClick: onUsbDetach">${DISCONNECT}</button>
                                 </td>
                             </tr>
                             <tr empty>


### PR DESCRIPTION
Per RFC: https://groups.google.com/forum/#!topic/openxt/RyvWd5-wAZ0

If the policy flag is set to false:
VMDetails
    - On USB tab, controls are disabled
    - 'Add USB Device' message is disabled
      and a tooltip dispcommitlays on mouseover
Devices
    - All USB controls are disabled

OXT-115

Signed-off-by: Ian Miller ian@coveycs.com
