### PR TITLE
Change process by which USB devices are reassigned

### DIFF
--- a/dist/script/models/hostModel.js
+++ b/dist/script/models/hostModel.js
@@ -617,18 +617,64 @@ XenClient.UI.HostModel = function() {
         dojo.forEach(devices, function(device) {
             var usb = self.usbDevices[device.dev_id];
             var sticky = (device.getSticky.length > 0 && device.getSticky[0] === true);
-            // Assignment
-            if (usb.assigned_uuid != device.assigned_uuid) {
-                if (device.assigned_uuid == "") {
-                    interfaces.usb.unassign_device(device.dev_id);
-                } else {
-                    interfaces.usb.assign_device(device.dev_id, device.assigned_uuid);
+
+            //Get the VM the device is currently assigned to if assigned to VM
+            var curVM = XUICache.getVM(XUtils.uuidToPath(usb.assigned_uuid)); 
+
+            var onError = function(error) {
+                XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
+            };
+
+            //Assignment
+            var assignUsb = function(reassigned, newVMPath){
+                if (reassigned){
+                    //After being unassigned, the device has the highest
+                    //available dev_id, so we just need to change the ID
+                    //to it.
+                    for(var dev in curVM.usbDevices){
+                        if (curVM.usbDevices.hasOwnProperty(dev)){
+                            if (dev > device.dev_id){
+                                device.dev_id = dev;
+                            }
+                        } 
+                    }
                 }
+                //Get the vm the device is going to be assigned to
+                var newVM = XUICache.getVM(XUtils.uuidToPath(newVMPath));
+                newVM.assignUsbDevice(device.dev_id, function() {
+                    if (sticky) {
+                        newVM.setUsbDeviceSticky(device.dev_id, true, undefined, onError);
+                    }
+                }, onError);
+                
+            };
+             
+            //Check if device is being reassigned 
+            if (usb.assigned_uuid != device.assigned_uuid) {
+                //just unassign if being assigned to none
+                if (device.assigned_uuid == "") {
+                    curVM.unassignUsbDevice(device.dev_id, function(){
+                       var interval = setInterval(function () {
+                           clearInterval(interval);
+                       }, 2000); 
+                    }, onError);
+                } else if (usb.assigned_uuid == ""){
+                //assign a non-assigned device to a vm
+                    assignUsb(false, device.assigned_uuid);
+                } else {
+                //reassign to new vm
+                    curVM.unassignUsbDevice(usb.dev_id, function(){
+                        var interval = setInterval(function() {
+                            clearInterval(interval);
+                            assignUsb(true, device.assigned_uuid);
+                        }, 2000);
+                    }, onError); 
+                }
+            } else {
+                //check sticky if device isn't being assigned or reassigned
+                curVM.setUsbDeviceSticky(device.dev_id, sticky, undefined, onError);
             }
-            // Sticky
-            if (usb.getSticky() != sticky) {
-                interfaces.usb.set_sticky(device.dev_id, sticky ? 1 : 0);
-            }
+ 
             // Name
             if (usb.name != device.name) {
                 interfaces.usb.name_device(device.dev_id, device.name);

--- a/widgets/xenclient/ConnectDevice.js
+++ b/widgets/xenclient/ConnectDevice.js
@@ -1,6 +1,7 @@
 define([
     "dojo",
     "dojo/_base/declare",
+    "dojo/_base/array",
     // Resources
     "dojo/i18n!citrix/xenclient/nls/ConnectDevice",
     "dojo/text!citrix/xenclient/templates/ConnectDevice.html",
@@ -15,7 +16,7 @@ define([
     "citrix/common/CheckBox",
     "citrix/common/Button"
 ],
-function(dojo, declare, connectDeviceNls, template, dialog, _boundContainerMixin) {
+function(dojo, declare, array, connectDeviceNls, template, dialog, _boundContainerMixin) {
 return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin], {
 
     templateString: template,
@@ -65,19 +66,52 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
         var onError = function(error) {
             XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
         };
-
-        var complete = function() {
+        
+        var complete = function(reassign) {
+            if(reassign){
+                for(var dev in vm.usbDevices){
+                    //vm.usbDevices is an object
+                    if (vm.usbDevices.hasOwnProperty(dev)){ 
+                        //newly reassigned usb device 
+                        //is the device with the hightest ID
+                        if (dev > usb.dev_id){
+                            usb.dev_id = dev;
+                        } 
+                    }
+                }     
+            }
             vm.assignUsbDevice(usb.dev_id, function() {
                 if (always) {
                     vm.setUsbDeviceSticky(usb.dev_id, true, undefined, onError);
                 }
             }, onError);
         };
+        
+        //We need to explicitly remove the USB during reassign 
+        var removeThenComplete = function() {
+            //get vm the device is assigned to
+            assignedUuid = usb.assigned_uuid; 
+            if (assignedUuid !== ""){
+                var curVM = XUICache.getVM(XUtils.uuidToPath(assignedUuid));    
+                curVM.unassignUsbDevice(usb.dev_id, function(){
+                    //Success 
+                    //Give some time for the device to be removed
+                    var interval = setInterval(function() {
+                        clearInterval(interval);
+                        complete(true);
+                    }, 2000);
+                }, function(error) {
+                    //error
+                    XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
+                }); 
+            }
+        
+        };
 
         if (usb.assignedToOtherVM()) {
             // Confirm stealing device from another VM
             var message = (usb.state == 2) ? this.USB_FORCE_REASSIGN : this.USB_REASSIGN;
-            XUICache.messageBox.showConfirmation(message, complete);
+            XUICache.messageBox.showConfirmation(message, removeThenComplete);
         } else {
             complete();
         }


### PR DESCRIPTION
To reassign devices, process is now

1) Unassign device from current VM
2) Wait 2 seconds
3) Reassign device to new VM

Also changed the usbDevices setter in the host model.

Instead of accessing the usb interface functions directly,
which did not work, the usbDevices setter now uses the vm model functions
to handle device assignemnts

OXT-116

Signed-off-by: Ian Miller ian@coveycs.com
