### PR TITLE
Add case to usbdaemon rpc to receive signal when new cd device detected

### DIFF
--- a/dist/script/index_cache.js
+++ b/dist/script/index_cache.js
@@ -308,6 +308,10 @@ XenClient.UI.Cache = (function() {
                         break;
                     case "com.citrix.xenclient.usbdaemon":
                         switch(member) {
+                            case "optical_device_detected":
+                                XUICache.Host.refresh();
+                                setTimeout(function() { XUICache.Host.refresh();}, 10);
+                                break;
                             case "devices_changed":
                             case "device_info_changed":
                                 XUICache.Host.refresh();


### PR DESCRIPTION
OXT-222

Upon receiving new signal from usbdaemon, trigger 2 host refreshes.
Due to some latency in the refresh function, a second refresh is
required (after a short delay) to reflect the new cd device in the devices list.

Signed-off by: Chris Rogers rogersc@ainfosec.com
