### PR TITLE
Changing process to refresh Devices dalog after plugging in new CD drive

### DIFF
--- a/dist/script/index_cache.js
+++ b/dist/script/index_cache.js
@@ -310,7 +310,6 @@ XenClient.UI.Cache = (function() {
                         switch(member) {
                             case "optical_device_detected":
                                 XUICache.Host.refresh();
-                                setTimeout(function() { XUICache.Host.refresh();}, 10);
                                 break;
                             case "devices_changed":
                             case "device_info_changed":

--- a/dist/script/lib/repository.js
+++ b/dist/script/lib/repository.js
@@ -214,6 +214,11 @@ XenClient.UI.Repository = function(model, readOnlyMap, readWriteMap, refreshIgno
                 fail(property);
             } else {
                 model[property] = value;
+                //Required to properly notify the UI when to update
+                //to show a newly plugged in USB CD Drive
+                if (property == "available_cds") {
+                    publish(XenConstants.TopicTypes.MODEL_USB_CHANGED);
+                }
                 publish(XenConstants.TopicTypes.MODEL_PROPERTY_CHANGED, property);
             }
         });


### PR DESCRIPTION
By watching for the exact property change, we can find the proper time
to refresh the Devices dialog, eliminating the need for two host refreshes

OXT-222

Signed-off-by: Ian Miller ian@coveycs.com
