### PR TITLE
Change process by which USB devices are reassigned

### DIFF
--- a/dist/script/models/hostModel.js
+++ b/dist/script/models/hostModel.js
@@ -2,7 +2,7 @@
 Namespace("XenClient.UI");
 
 XenClient.UI.HostModel = function() {
-    
+
     // Private stuffs
     var self = this;
 
@@ -240,10 +240,10 @@ XenClient.UI.HostModel = function() {
         "build_tools",
         "build_version"
     ];
-    
+
     // Repository
     var repository = new XenClient.UI.Repository(this, readOnlyMap, readWriteMap, refreshIgnoreMap);
-    
+
     function fail(error) {
         self.publish(XenConstants.TopicTypes.MODEL_FAILURE, error);
     }
@@ -262,7 +262,7 @@ XenClient.UI.HostModel = function() {
                 self.max_vm_memory = self.total_mem; // Math.min(self.total_mem, XenConstants.VMLimits.MEMORY);
 
                 self.load_pluginSubDirs();
-                
+
                 var count;
                 var name;
 
@@ -304,6 +304,7 @@ XenClient.UI.HostModel = function() {
         self.refreshUsb(wait.addCallback());
         self.refreshAudio(wait.addCallback());
         wait.finish();
+
     };
 
     this.refreshResources = function(finish) {
@@ -561,7 +562,7 @@ XenClient.UI.HostModel = function() {
                 }
                 return false;
             });
-        });        
+        });
     };
 
     // audioControls setter
@@ -617,7 +618,82 @@ XenClient.UI.HostModel = function() {
         dojo.forEach(devices, function(device) {
             var usb = self.usbDevices[device.dev_id];
             var sticky = (device.getSticky.length > 0 && device.getSticky[0] === true);
-            // Assignment
+
+            ///TEMPORARY FIX
+            ///ref OXT-116: https://openxt.atlassian.net/browse/OXT-116
+            ///Fix can be removed after rewrite/modification of vusb daemon fixes
+            ///race condition.
+
+            //Get the VM the device is currently assigned to if assigned to VM
+            if (usb.assigned_uuid != ""){
+                var curVM = XUICache.getVM(XUtils.uuidToPath(usb.assigned_uuid));
+            }
+
+            var onError = function(error) {
+                XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
+            };
+
+            //Assignment
+            var assignUsb = function(reassigned, newVMPath){
+                if (reassigned){
+                    //After being unassigned, the device has the highest
+                    //available dev_id, so we just need to change the ID
+                    //to it.
+                    for(var dev in curVM.usbDevices){
+                        if (curVM.usbDevices.hasOwnProperty(dev)){
+                            if (dev > device.dev_id &&
+                                curVM.usbDevices[dev].state != 7 &&
+                                curVM.usbDevices[dev].state != 8 &&
+                                curVM.usbDevices[dev].state != 10
+                            ){
+                                device.dev_id = dev;
+                            }
+                        }
+                    }
+                }
+                //Get the vm the device is going to be assigned to
+                var newVM = XUICache.getVM(XUtils.uuidToPath(newVMPath));
+                newVM.assignUsbDevice(device.dev_id, function() {
+                    if (sticky) {
+                        newVM.setUsbDeviceSticky(device.dev_id, true, undefined, onError);
+                    }
+                }, onError);
+
+            };
+
+            //Check if device is being reassigned
+            if (usb.assigned_uuid != device.assigned_uuid) {
+                //just unassign if being assigned to none
+                if (device.assigned_uuid == "") {
+                    curVM.unassignUsbDevice(device.dev_id, function(){
+                       var interval = setInterval(function () {
+                           clearInterval(interval);
+                       }, 2000);
+                    }, onError);
+                } else if (usb.assigned_uuid == ""){
+                //assign a non-assigned device to a vm
+                    assignUsb(false, device.assigned_uuid);
+                } else {
+                //reassign to new vm
+                    curVM.unassignUsbDevice(usb.dev_id, function(){
+                        var interval = setInterval(function() {
+                            clearInterval(interval);
+                            assignUsb(true, device.assigned_uuid);
+                        }, 2000);
+                    }, onError);
+                }
+            } else {
+                //check sticky if device isn't being assigned or reassigned
+                if(curVM){
+                    curVM.setUsbDeviceSticky(device.dev_id, sticky, undefined, onError);
+                }
+            }
+            ///END TEMPORARY FIX
+
+
+            ///ORIGINAL CODE, REPLACE TEMPORARY FIX WITH THIS
+            ///WHEN PERMENANT FIX COMPLETE
+            /*
             if (usb.assigned_uuid != device.assigned_uuid) {
                 if (device.assigned_uuid == "") {
                     interfaces.usb.unassign_device(device.dev_id);
@@ -625,15 +701,20 @@ XenClient.UI.HostModel = function() {
                     interfaces.usb.assign_device(device.dev_id, device.assigned_uuid);
                 }
             }
-            // Sticky
+
+            //Sticky
             if (usb.getSticky() != sticky) {
                 interfaces.usb.set_sticky(device.dev_id, sticky ? 1 : 0);
             }
+
             // Name
             if (usb.name != device.name) {
                 interfaces.usb.name_device(device.dev_id, device.name);
             }
+            */
+            ///END ORIGINAL CODE
         });
+
     };
 
     this.getPlatformDevices = function() {
@@ -700,7 +781,7 @@ XenClient.UI.HostModel = function() {
     this.canModifyServices = function() {
         if (self.isDeferred()) {
             return false;
-        }        
+        }
         return (self.policy_modify_services && XUICache.getServiceVMCount() > 0);
     };
 
@@ -806,7 +887,7 @@ XenClient.UI.HostModel = function() {
     };
 
     this.getNetworks = function() {
-        var networkList = [];        
+        var networkList = [];
         dojo.forEach(self.available_networks, function(network) {
             // Don't show unknown devices
             if (network.type == XenConstants.Network.NETWORK_TYPE.UNKNOWN) {

--- a/widgets/xenclient/Devices.js
+++ b/widgets/xenclient/Devices.js
@@ -20,6 +20,11 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
 
     templateString: template,
     widgetsInTemplate: true,
+    ///PART OF TEMPORARY FIX
+    ///ref OXT-116: https://openxt.atlassian.net/browse/OXT-116
+    ///Fix can be removed after rewrite/modification of vusb daemon
+    _userChanged: false,
+    ///END PART OF TEMPORARY FIX
 
     constructor: function(args) {
         this.host = XUICache.Host;
@@ -73,7 +78,7 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
                             vm = XUICache.VMs[path];
                             if (vm.isRunning()) {
                                 usbCDAssigned = true;
-                            }                            
+                            }
                         }
                     }
 
@@ -105,7 +110,7 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
 
             }));
         });
-        
+
         if (forcedDevices.length > 0) {
             // Confirm stealing device from another VM
             var message = this.DEVICE_FORCE_REASSIGN.format(forcedDevices.join("<br/>"));
@@ -125,7 +130,7 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
     },
 
     _bindDijit: function() {
-        this._setupMaps();        
+        this._setupMaps();
         this.bind(this.host);
         this._onCDChange();
         this._onUSBChange();
@@ -161,10 +166,36 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
         }, this);
     },
 
+    ///TEMPORARY FIX
+    ///ref OXT-116: https://openxt.atlassian.net/browse/OXT-116
+    ///Fix can be removed after rewrite/modification of vusb daemon
+    _onUSBAssignmentChange: function() {
+        //Including original function so we don't break anything
+        this._onUSBChange();
+
+        //Save if the dialog is open and the user initiated the value change
+        if (this.open && this._userChanged){
+            this._userChanged = false;
+            this.save();
+        }
+    },
+    ///END TEMPORARY FIX
+
     _onUSBChange: function() {
         dojo.forEach(XUICache.Host.get_usbDevices(), function(usb) {
             this._setControls(usb.dev_id, "usb");
-        }, this);        
+        }, this);
+    },
+
+    // The next two functions are necessary to see if
+    // the select box value is being user changed or
+    // programatically changed
+    _setUserChanged: function() {
+        this._userChanged = true;
+    },
+
+    _unsetUserChanged: function() {
+        this._userChanged = false;
     },
 
     _setControls: function(deviceID, prefix) {
@@ -185,13 +216,13 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
                 this._setEnabled(check, false);
                 this._setEnabled(select, false);
             }
-        } 
+        }
         if (name) {
             if (prefix == "usb" && !this.host.policy_modify_usb_settings){
                 this._setEnabled(name, false);
             }
         }
-         
+
     },
 
     _messageHandler: function(message) {
@@ -207,7 +238,7 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
             case XenConstants.TopicTypes.UI_VMNAME_CHANGED: {
                 this._setupMaps();
                 break;
-            }            
+            }
         }
     }
 });

--- a/widgets/xenclient/templates/Devices.html
+++ b/widgets/xenclient/templates/Devices.html
@@ -57,7 +57,9 @@
                         <span templateType="citrix.common.ValidationTextBox" id="usb_name_%dev_id%" bind="name" maxLength="60" required="true" regExpObject="XenConstants.Regex.USB_NAME" invalidMessage="${NAME_VALERROR}"></span>
                     </td>
                     <td>
-                        <select class="citrix" templateType="citrix.common.Select" id="usb_select_%dev_id%" optionsKey="usbVMList" bind="assigned_uuid" dojoAttachEvent="onChange: _onUSBChange"></select>
+                    <!-- PART OF TEMPORARY FIX, SEE _setUserChanged in ../Devices.js -->
+                        <select class="citrix" templateType="citrix.common.Select" id="usb_select_%dev_id%" optionsKey="usbVMList" bind="assigned_uuid" dojoAttachEvent="onChange: _onUSBAssignmentChange, onFocus: _setUserChanged, onBlur: _unsetUserChanged" ></select>
+                    <!-- END TEMPORARY FIX -->
                     </td>
                     <td class="noWrap" colspan="2">
                         <span templateType="citrix.common.CheckBox" id="usb_check_%dev_id%" bind="getSticky" dojoAttachEvent="onChange: _onUSBChange"></span>


### PR DESCRIPTION
To reassign devices, process is now

1) Unassign device from current VM
2) Wait 2 seconds
3) Reassign device to new VM

Also changed the usbDevices setter in the host model.

Instead of accessing the usb interface functions directly,
which did not work, the usbDevices setter now uses the vm model functions
to handle device assignemnts

OTHER CHANGES

Forcing saving of devices dialog on device reassignment.
This avoids an issue where reassigning more than two devices
at once causes all devices to be assigned to none.

NOTE: ALL THESE CHANGES ARE TEMPORARY AND SHOULD BE ROLLED BACK
WHEN THE vUSB DAEMON IS REWRITTEN.

OXT-116

Signed-off-by: Ian Miller ian@coveycs.com
