### PR TITLE
OXT-227 Fix default xc-tools.iso behavior

### DIFF
--- a/widgets/xenclient/MediaWizard.js
+++ b/widgets/xenclient/MediaWizard.js
@@ -86,7 +86,11 @@ return declare("citrix.xenclient.MediaWizard", [_wizard], {
                 // Initial properties for created VM
                 vm.vcpus = result.vcpus;
                 vm.memory = result.memory;
-                vm.cd = (result.autoStart == "iso") ? result.iso : XenConstants.Defaults.TOOLS_ISO;
+                var hasToolsISO = dojo.some(XUICache.Host.available_isos, function(iso) {
+                    return iso == XenConstants.Defaults.TOOLS_ISO;
+                }, this);
+                var toolsISO = hasToolsISO ? XenConstants.Defaults.TOOLS_ISO : "";
+                vm.cd = (result.autoStart == "iso") ? result.iso : toolsISO;
                 vm.boot = (result.autoStart == "network") ? "cn" : "cd";
 
                 var save = function() {

--- a/widgets/xenclient/VMDetails.js
+++ b/widgets/xenclient/VMDetails.js
@@ -436,7 +436,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
         var isoMap = {};
         isoMap[this.NONE] = "";
         dojo.forEach(XUICache.Host.available_isos, function(iso) {
-            isoMap[(XUICache.Host.available_isos.length == 1) ? this.TOOLS_CD : iso] = iso;
+            isoMap[(iso.indexOf(XenConstants.Defaults.TOOLS_ISO)>-1) ? this.TOOLS_CD : iso] = iso;
         }, this);
 
         this.isos.set("map", isoMap);


### PR DESCRIPTION
The new/corrected behavior:
-During VM creation, if the xc-tools.iso is present in /storage/isos and
autostart is not set to "iso" then xc-tools.iso is set to be the default cd.
Otherwise, it is set to "None" ("").

-On the VM Details screen Hardware tab, if xc-tools.iso is present then
it will appear in the drop down as "OpenXT Guest Tools".  Any other ISO
will appear as it's file name.

Note: the list of available isos is currently updated only on the initial UI load.

OXT-227

Signed-off-by: Andrew 'Doc' Docherty doc@coveycs.com
