### PR TITLE
VM Disks are no longer deleteable when modify-vm-settings is false

### DIFF
--- a/widgets/xenclient/VMDetails.js
+++ b/widgets/xenclient/VMDetails.js
@@ -307,7 +307,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
     onRestoreSnapshot: function(event) {
         var path = this._getDeviceID(event.target);
         var popup = new restoreSnapshot({ vm_path: this.vm.vm_path, disk_path: path });
-        popup.show();        
+        popup.show();
     },
 
     onAudioChange: function(value) {
@@ -390,7 +390,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
             this._setDisplay(this[action + "Action"], allowedActions.contains(action));
             this._setEnabled(this[action + "Action"], !this.vm.powerClicked);
         }, this);
-        
+
         if(!this.vm.isUserVM()) {
             this._setDisplay(".userVmOnly", false);
             this._setEnabled(".userVmOnlyDisable", false);
@@ -623,6 +623,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
             case XenConstants.TopicTypes.MODEL_DISK_USAGE_CHANGED: {
                 this.bind(this.vm, this.diskTab.domNode);
                 this.bindTooltips();
+                this._setEnabled(".diskButton", this.vm.canEditDisk());
                 break;
             }
             case XenConstants.TopicTypes.MODEL_NIC_CHANGED: {


### PR DESCRIPTION
When the MODEL_DISKS_CHANGED topic is published, bind is called
and the repeater displaying the disks is reloaded
but it doesn't check to see if the disks are allowed to be
deleted or not, so the button is re-enabled.

Solution was to add that check in after the bind.

OXT-98

Signed-off-by: Ian Miller ian@coveycs.com
