### PR TITLE
Requiring KeyUp events to be preceded by KeyDown

### DIFF
--- a/widgets/xenclient/_VMButton.js
+++ b/widgets/xenclient/_VMButton.js
@@ -13,13 +13,14 @@ return declare("citrix.xenclient._VMButton", [_widget, _templated, _contained, _
     widgetsInTemplate: true,
     _focusCounter: 0,
     _focusThreshold: 3,
+    _keyDown: false,
 
     postCreate: function() {
         this.containerNode.setAttribute("role", "button");
 		if(!this.containerNode.getAttribute("tabIndex")){
 			this.containerNode.setAttribute("tabIndex", 0);
 		}
-        this.on("keyup", this._onKeyPress);
+        this.on("keydown", this._onKeyPress);
         this.inherited(arguments);
     },
 
@@ -50,9 +51,20 @@ return declare("citrix.xenclient._VMButton", [_widget, _templated, _contained, _
     },
 
     _onKeyPress: function(event){
-        if (event.keyCode == dojo.keys.SPACE || event.keyCode == dojo.keys.ENTER) {
-            this.activate(event);
+        //only start listening for keyup after key down
+        if (!this.keyDown){
+            var signal = this.on("keyup", function() {
+                if (event.keyCode == dojo.keys.SPACE || event.keyCode == dojo.keys.ENTER) {
+                    this.activate(event);
+                }
+
+                this.keyDown = false;
+                //remove the listener so we need to get another
+                //keydown first
+                signal.remove();
+            });
         }
+        this.keyDown = true;
     }
 });
 });

--- a/widgets/xenclient/_VMButton.js
+++ b/widgets/xenclient/_VMButton.js
@@ -52,19 +52,19 @@ return declare("citrix.xenclient._VMButton", [_widget, _templated, _contained, _
 
     _onKeyPress: function(event){
         //only start listening for keyup after key down
-        if (!this.keyDown){
+        if (!this._keyDown){
             var signal = this.on("keyup", function() {
                 if (event.keyCode == dojo.keys.SPACE || event.keyCode == dojo.keys.ENTER) {
                     this.activate(event);
                 }
 
-                this.keyDown = false;
+                this._keyDown = false;
                 //remove the listener so we need to get another
                 //keydown first
                 signal.remove();
             });
         }
-        this.keyDown = true;
+        this._keyDown = true;
     }
 });
 });


### PR DESCRIPTION
This prevents the KeyUp listener in _VMButton.js from starting a VM
when exiting a terminal by using the 'exit' command if the
mouse cursor is over a VM button when pressing enter.

OXT-282

Signed-off-by: Ian Miller ian@coveycs.com
