### PR TITLE
3D Graphics PCI Pass Through Prompt

### DIFF
--- a/widgets/xenclient/DisplayPCI.js
+++ b/widgets/xenclient/DisplayPCI.js
@@ -1,0 +1,63 @@
+define([
+    "dojo",
+    "dojo/_base/declare",
+    // Resources
+    "dojo/i18n!citrix/xenclient/nls/DisplayPCI",
+    "dojo/text!citrix/xenclient/templates/DisplayPCI.html",
+    // Mixins
+    "citrix/common/Dialog",
+    "citrix/common/_BoundContainerMixin",
+    // Required in template
+    "citrix/common/Repeater",
+    "citrix/common/BoundWidget",
+    "citrix/common/Button"
+],
+function(dojo, declare, displayPCINls, template, dialog, _boundContainerMixin) {
+return declare("citrix.xenclient.DisplayPCI", [dialog, _boundContainerMixin], {
+
+    templateString: template,
+    widgetsInTemplate: true,
+    canExecute: true,
+    destroyOnHide: true,
+
+    constructor: function(args) {
+        this.vm = XUICache.getVM(args.path);
+        this.devicesOnGPUBus = args.devicesOnGPUBus;
+        this.cancelCallback = args.cancelCallback;
+    },
+
+    postMixInProperties: function() {
+        dojo.mixin(this, displayPCINls);
+        this.inherited(arguments);
+    },
+    postCreate: function() {
+        this.inherited(arguments);
+        this.subscribe(this.vm.publish_topic, this._messageHandler);
+        this._bindDijit();
+    },
+    
+    _bindDijit: function() {
+        this.bind(this);
+        this.set("title", this.DISPLAY_DEVICE);
+    },
+
+    onExecute: function(){
+        this.inherited(arguments);
+    },
+
+    onCancel: function(){
+        this.inherited(arguments);        
+        this.cancelCallback();
+    },
+
+    _messageHandler: function(message) {
+        switch(message.type) {
+            case XenConstants.TopicTypes.MODEL_STATE_CHANGED:
+            case XenConstants.TopicTypes.MODEL_CHANGED: {
+                this._bindDijit();
+                break;
+            }
+        }
+    }
+});
+});

--- a/widgets/xenclient/VMDetails.js
+++ b/widgets/xenclient/VMDetails.js
@@ -16,6 +16,7 @@ define([
     "citrix/xenclient/AddDisk",
     "citrix/xenclient/ConnectDevice",
     "citrix/xenclient/ConnectPCI",
+    "citrix/xenclient/DisplayPCI",
     "citrix/xenclient/RestoreSnapshot",
     "citrix/common/ItemFileReadStore",
     "citrix/common/EditableWidget",
@@ -39,7 +40,7 @@ define([
     "citrix/common/ProgressBar",
     "citrix/common/CheckBox"
 ],
-function(dojo, declare, registry, vmDetailsNls, vmNls, template, dialog, _boundContainerMixin, _editableMixin, _citrixTooltipMixin, addNic, addDisk, connectDevice, connectPCI, restoreSnapshot, itemFileReadStore, editableWidget, label, boundWidget, domConstruct) {
+function(dojo, declare, registry, vmDetailsNls, vmNls, template, dialog, _boundContainerMixin, _editableMixin, _citrixTooltipMixin, addNic, addDisk, connectDevice, connectPCI, displayPCI, restoreSnapshot, itemFileReadStore, editableWidget, label, boundWidget, domConstruct) {
 return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _editableMixin, _citrixTooltipMixin], {
 
 	templateString: template,
@@ -340,6 +341,24 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
             this.audioRecordingNode.set("value", value);
         }
     },
+
+    onThreeDChange: function(addr) {
+        // find all devices on the same bus
+        var devicesOnGPUBus = this.vm.getPCIDevices().filter(function(device){
+            return device.addr != addr && //difference address than gpu itself
+                   parseInt(device.addr.split(":")[1]) == parseInt(addr.split(":")[1]);
+            })         
+        if (addr && this.value.gpu != addr && devicesOnGPUBus.length){
+            var popup = new displayPCI({
+                path: this.vm.vm_path, 
+                devicesOnGPUBus: devicesOnGPUBus,
+                cancelCallback: dojo.hitch(this, function(){
+                    this.threed.set('value', this.vm.gpu);
+                })
+            });     
+            popup.show();
+         }      
+    },  
 
     onPciAdd: function() {
         var popup = new connectPCI({ path: this.vm.vm_path });

--- a/widgets/xenclient/nls/DisplayPCI.js
+++ b/widgets/xenclient/nls/DisplayPCI.js
@@ -1,0 +1,8 @@
+({
+    // Layout
+    DISPLAY_DEVICE: "Attention",
+    DEVICE_PROMPT: "When this guest is started, the following additional PCI devices and functions will be passed through:",
+    DISPLAY_ACTION: "OK",
+    DISPLAY_CANCEL: "Cancel",
+    PCI_INFO: "Address: {0}, Class: {1}",
+})

--- a/widgets/xenclient/nls/de-de/DisplayPCI.js
+++ b/widgets/xenclient/nls/de-de/DisplayPCI.js
@@ -1,0 +1,8 @@
+({
+    // Layout
+    DISPLAY_DEVICE: "Attention",
+    DEVICE_PROMPT: "When this guest is started, the following additional PCI devices and functions will be passed through:",
+    DISPLAY_ACTION: "OK",
+    DISPLAY_CANCEL: "Cancel",
+    PCI_INFO: "Address: {0}, Class: {1}",
+})

--- a/widgets/xenclient/nls/es-es/DisplayPCI.js
+++ b/widgets/xenclient/nls/es-es/DisplayPCI.js
@@ -1,0 +1,8 @@
+({
+    // Layout
+    DISPLAY_DEVICE: "Attention",
+    DEVICE_PROMPT: "When this guest is started, the following additional PCI devices and functions will be passed through:",
+    DISPLAY_ACTION: "OK",
+    DISPLAY_CANCEL: "Cancel",
+    PCI_INFO: "Address: {0}, Class: {1}",
+})

--- a/widgets/xenclient/nls/fr-fr/DisplayPCI.js
+++ b/widgets/xenclient/nls/fr-fr/DisplayPCI.js
@@ -1,0 +1,8 @@
+({
+    // Layout
+    DISPLAY_DEVICE: "Attention",
+    DEVICE_PROMPT: "When this guest is started, the following additional PCI devices and functions will be passed through:",
+    DISPLAY_ACTION: "OK",
+    DISPLAY_CANCEL: "Cancel",
+    PCI_INFO: "Address: {0}, Class: {1}",
+})

--- a/widgets/xenclient/nls/ja-jp/DisplayPCI.js
+++ b/widgets/xenclient/nls/ja-jp/DisplayPCI.js
@@ -1,0 +1,8 @@
+({
+    // Layout
+    DISPLAY_DEVICE: "Attention",
+    DEVICE_PROMPT: "When this guest is started, the following additional PCI devices and functions will be passed through:",
+    DISPLAY_ACTION: "OK",
+    DISPLAY_CANCEL: "Cancel",
+    PCI_INFO: "Address: {0}, Class: {1}",
+})

--- a/widgets/xenclient/nls/zh-cn/DisplayPCI.js
+++ b/widgets/xenclient/nls/zh-cn/DisplayPCI.js
@@ -1,0 +1,8 @@
+({
+    // Layout
+    DISPLAY_DEVICE: "Attention",
+    DEVICE_PROMPT: "When this guest is started, the following additional PCI devices and functions will be passed through:",
+    DISPLAY_ACTION: "OK",
+    DISPLAY_CANCEL: "Cancel",
+    PCI_INFO: "Address: {0}, Class: {1}",
+})

--- a/widgets/xenclient/templates/DisplayPCI.html
+++ b/widgets/xenclient/templates/DisplayPCI.html
@@ -1,0 +1,27 @@
+<div class="citrixDialog alertDialog" dojoAttachPoint="containerNode" tabindex="-1" waiRole="dialog" waiState="labelledby-${id}_title">
+	<div class="citrixDialogTitleBar">
+        <span dojoAttachPoint="titleNode" class="citrixDialogTitle" id="${id}_title"></span>
+        <span dojoAttachPoint="closeButtonNode" class="citrixDialogCloseIcon" dojoAttachEvent="onclick: onCancel">
+            <span dojoAttachPoint="closeText"></span>
+        </span>
+	</div>
+    <div class="citrixDialogPaneContent">
+        <div class="left alertIcon alertIconLarge alertIconWarning"></div>
+        <div class="alertMessage" >${DEVICE_PROMPT}</div>
+        <ul class="connectDevice" dojoType="citrix.common.Repeater"  name="devicesOnGPUBus" uniqueId="addr" >
+            <li template deviceId="%addr%">
+                <div class="device" templateType="citrix.common.BoundWidget" binding="disabled"  >
+                    <div class="deviceItem deviceName" templateType="citrix.common.BoundWidget" bind="name"></div>
+                    <div class="deviceItem" templateType="citrix.common.BoundWidget" bind="info" mask="${PCI_INFO}"></div>
+                </div>
+            </li>
+            <li empty class="noDevices"></li>
+        </ul>
+    </div>
+    <div dojoAttachPoint="footerNode" class="citrixDialogFooterContent">
+        <span class="citrixDialogFooter right">
+            <button dojoAttachPoint="continueButton" dojoType="citrix.common.Button" class="citrixDialogItemRight" dojoAttachEvent="onClick: onExecute">${DISPLAY_ACTION}</button>
+            <button dojoAttachPoint="closeButton" dojoType="citrix.common.Button" class="citrixDialogItemRight" dojoAttachEvent="onClick: onCancel">${DISPLAY_CANCEL}</button>
+        </span>
+    </div>
+</div>

--- a/widgets/xenclient/templates/VMDetails.html
+++ b/widgets/xenclient/templates/VMDetails.html
@@ -74,7 +74,7 @@
                     </div>
                     <div class="citrixTabPaneField userVmOnly">
                         <label dojoType="citrix.common.Label" dojoAttachPoint="threedLabel" for="gpu" title="${HDX_TOOLTIP}">${THREED_GFX}</label>
-                        <span class="value userVmOnlyDisable" dojoAttachPoint="threed" dojoType="citrix.common.EditableWidget" editor="citrix.common.Select" name="gpu"></span>
+                        <span class="value userVmOnlyDisable" dojoAttachPoint="threed" dojoAttachEvent="onChange: onThreeDChange" dojoType="citrix.common.EditableWidget" editor="citrix.common.Select" name="gpu"></span>
                     </div>
                     <div class="citrixTabPaneField">
                         <label for="cd">${VIRTUAL_CD}</label>


### PR DESCRIPTION
Add a dialog that prompts the user so that they are aware of any
other PCI devices on the 3d card's bus that will be passed through
to the guest.

Expected behavior:

In the VM Details dialog, on hardware tab, the user makes a selection
in the "3D Graphics (experimental)" drop down.  A dialog should appear
if:
- There are other devices on the gpu bus that will be passed through
  AND
- The use makes a selection besides disabled (either Enabled or the
  specific card on multi-gpu boxes)

A dialog will appear warning a user about the other devices being
passed through, along with a list of those devices.

The user may click "OK" to dismiss the dialog, or "Cancel" which
sets the drop down to the last saved setting.  The top right "X" works
the same as "Cancel".

OXT-281

Signed-off-by: Andrew 'Doc' Docherty doc@coveycs.com
