### PR TITLE
Add support for separate Battery topic for changed events

### DIFF
--- a/dist/script/constants.js
+++ b/dist/script/constants.js
@@ -309,6 +309,7 @@ XenClient.Resource.TopicTypes = {
 
     // Battery Topics
     UI_BATTERIES_LOADED     : "batteriesloaded",
+    UI_BATTERIES_CHANGED    : "batterieschanged",
     BATTERY_CRITICAL        : "batterycritical"
 };
 

--- a/dist/script/index_cache.js
+++ b/dist/script/index_cache.js
@@ -144,7 +144,7 @@ XenClient.UI.Cache = (function() {
                device.refresh();
            }
         }
-        XUtils.publish(XenConstants.TopicTypes.MODEL_CHANGED);
+        XUtils.publish(XenConstants.TopicTypes.UI_BATTERIES_CHANGED);
     };
 
     var allVMPaths = function() {

--- a/dist/script/models/batteryModel.js
+++ b/dist/script/models/batteryModel.js
@@ -63,7 +63,7 @@ XenClient.UI.BatteryModel = function(bat_num) {
            if(this.bat_index>-1)
            {
              XUICache.Batteries[this.bat_index].percent=percent;
-             self.publish(XenConstants.TopicTypes.MODEL_CHANGED);
+             self.publish(XenConstants.TopicTypes.UI_BATTERIES_CHANGED);
            } 
          
         }
@@ -121,7 +121,7 @@ XenClient.UI.BatteryModel = function(bat_num) {
           if(this.bat_index>-1)
           {
                 XUICache.Batteries[this.bat_index].adapter_state=acState;
-                self.publish(XenConstants.TopicTypes.MODEL_CHANGED);
+                self.publish(XenConstants.TopicTypes.UI_BATTERIES_CHANGED);
           }
           
         }

--- a/widgets/xenclient/BatteryFooterBarItem.js
+++ b/widgets/xenclient/BatteryFooterBarItem.js
@@ -183,6 +183,11 @@ return declare("citrix.xenclient.BatteryFooterBarItem", [footerBarItem], {
                 this._bindDijit();
                 break;
             }
+           case XenConstants.TopicTypes.UI_BATTERIES_CHANGED: {
+                this._bindDijit();
+                break;
+            }
+                                                               //UI_BATTERIES_CHANGED
 
         }
     }


### PR DESCRIPTION
This revision to multibattery and xcpmd support adds a new Topic Type of UI_BATTERY_CHANGED to replace usage of MODEL_CHANGED. This prevents other UI areas from being updated repeatedly when xcpmd sends battery changed events. 

XT-295

Signed-off-by: David Marslandmarslandd@aol.com
