### PR TITLE
Maintain Nic policy

### DIFF
--- a/widgets/xenclient/VMDetails.js
+++ b/widgets/xenclient/VMDetails.js
@@ -676,6 +676,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
             case XenConstants.TopicTypes.MODEL_NIC_CHANGED: {
                 this.bind(this.vm, this.nicTab.domNode);
                 this.bindTooltips();
+                this._setEnabled(".nicButton", this.vm.canEditNics());
                 break;
             }
             case XenConstants.TopicTypes.MODEL_USB_CHANGED: {


### PR DESCRIPTION
Enforces policy-modify-vm-settings pertaining to adding or removing NDVMs after the UI rebinds after a MODEL_NIC_CHANGED event.

Previously the enforcement would be intermittent. 

Signed-off-by: Andrew 'Doc' Docherty doc@coveycs.com
