### PR TITLE
Correct hard battery error on tablet computers

### DIFF
--- a/dist/script/index_cache.js
+++ b/dist/script/index_cache.js
@@ -144,7 +144,10 @@ XenClient.UI.Cache = (function() {
                device.refresh();
            }
         }
-        XUtils.publish(XenConstants.TopicTypes.UI_BATTERIES_CHANGED);
+        if(bat_count>-1)
+        {// do not refresh the batteries if there are none, may be in the midst of a refresh
+           XUtils.publish(XenConstants.TopicTypes.UI_BATTERIES_CHANGED);
+        }
     };
 
     var allVMPaths = function() {

--- a/dist/script/models/batteryModel.js
+++ b/dist/script/models/batteryModel.js
@@ -133,7 +133,10 @@ XenClient.UI.BatteryModel = function(bat_num) {
       this.bat_index = XUICache.Host.available_batteries.indexOf(this.bat_num);
 
       var error = function(error) {
-          XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
+        if(this.bat_num!=undefined)
+        {// suppress errors if the batteries are in the midst of being refreshed
+           XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
+        }
       };
       var self=this;
 


### PR DESCRIPTION
This change addresses an error seen in testing with combination
laptop/tablet computers where removing the tablet causes a battery
slot error message to appear.

Signed off by: David Marsland
