### PR TITLE
OXT-236 - Remove workaround for USB Devices

### DIFF
--- a/dist/script/models/hostModel.js
+++ b/dist/script/models/hostModel.js
@@ -620,81 +620,6 @@ XenClient.UI.HostModel = function() {
             var usb = self.usbDevices[device.dev_id];
             var sticky = (device.getSticky.length > 0 && device.getSticky[0] === true);
 
-            ///TEMPORARY FIX
-            ///ref OXT-116: https://openxt.atlassian.net/browse/OXT-116
-            ///Fix can be removed after rewrite/modification of vusb daemon fixes
-            ///race condition.
-
-            //Get the VM the device is currently assigned to if assigned to VM
-            if (usb.assigned_uuid != ""){
-                var curVM = XUICache.getVM(XUtils.uuidToPath(usb.assigned_uuid));
-            }
-
-            var onError = function(error) {
-                XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
-            };
-
-            //Assignment
-            var assignUsb = function(reassigned, newVMPath){
-                if (reassigned){
-                    //After being unassigned, the device has the highest
-                    //available dev_id, so we just need to change the ID
-                    //to it.
-                    for(var dev in curVM.usbDevices){
-                        if (curVM.usbDevices.hasOwnProperty(dev)){
-                            if (dev > device.dev_id &&
-                                curVM.usbDevices[dev].state != 7 &&
-                                curVM.usbDevices[dev].state != 8 &&
-                                curVM.usbDevices[dev].state != 10
-                            ){
-                                device.dev_id = dev;
-                            }
-                        }
-                    }
-                }
-                //Get the vm the device is going to be assigned to
-                var newVM = XUICache.getVM(XUtils.uuidToPath(newVMPath));
-                newVM.assignUsbDevice(device.dev_id, function() {
-                    if (sticky) {
-                        newVM.setUsbDeviceSticky(device.dev_id, true, undefined, onError);
-                    }
-                }, onError);
-
-            };
-
-            //Check if device is being reassigned
-            if (usb.assigned_uuid != device.assigned_uuid) {
-                //just unassign if being assigned to none
-                if (device.assigned_uuid == "") {
-                    curVM.unassignUsbDevice(device.dev_id, function(){
-                       var interval = setInterval(function () {
-                           clearInterval(interval);
-                       }, 2000);
-                    }, onError);
-                } else if (usb.assigned_uuid == ""){
-                //assign a non-assigned device to a vm
-                    assignUsb(false, device.assigned_uuid);
-                } else {
-                //reassign to new vm
-                    curVM.unassignUsbDevice(usb.dev_id, function(){
-                        var interval = setInterval(function() {
-                            clearInterval(interval);
-                            assignUsb(true, device.assigned_uuid);
-                        }, 2000);
-                    }, onError);
-                }
-            } else {
-                //check sticky if device isn't being assigned or reassigned
-                if(curVM){
-                    curVM.setUsbDeviceSticky(device.dev_id, sticky, undefined, onError);
-                }
-            }
-            ///END TEMPORARY FIX
-
-
-            ///ORIGINAL CODE, REPLACE TEMPORARY FIX WITH THIS
-            ///WHEN PERMENANT FIX COMPLETE
-            /*
             if (usb.assigned_uuid != device.assigned_uuid) {
                 if (device.assigned_uuid == "") {
                     interfaces.usb.unassign_device(device.dev_id);
@@ -712,8 +637,6 @@ XenClient.UI.HostModel = function() {
             if (usb.name != device.name) {
                 interfaces.usb.name_device(device.dev_id, device.name);
             }
-            */
-            ///END ORIGINAL CODE
         });
 
     };

--- a/dist/script/models/vmModel.js
+++ b/dist/script/models/vmModel.js
@@ -676,6 +676,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(usb == undefined)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.state = 4;
         interfaces.usb.assign_device(usb.dev_id, self.uuid, onSuccess, failure);
     };
@@ -688,6 +692,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(usb == undefined)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.state = 0;
         interfaces.usb.unassign_device(usb.dev_id, onSuccess, failure);
     };
@@ -700,6 +708,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(usb == undefined)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.state = (self.getState() == XenConstants.VMStates.VM_RUNNING) ? 5 : 6;
         interfaces.usb.set_sticky(usb.dev_id, sticky ? 1 : 0, onSuccess, failure);
     };
@@ -712,6 +724,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(usb == undefined)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.name = name;
         interfaces.usb.name_device(dev_id, name, onSuccess, failure);
     };
@@ -953,7 +969,7 @@ XenClient.UI.VMModel = function(vm_path) {
 
     this.deleteVisible = function() {
         return (self.policy_modify_vm && XUICache.Host.policy_delete_vm);
-    };    
+    };
 
     this.canModifyPCI = function() {
         return (self.policy_modify_vm && self.getState() == XenConstants.VMStates.VM_STOPPED);
@@ -1007,7 +1023,7 @@ XenClient.UI.VMModel = function(vm_path) {
     this.getTransferSpeed = function() {
         return 0;
     };
-    
+
     this.getAvailableDevices = function() {
         var devices = [];
         for (var id in self.usbDevices) {

--- a/widgets/xenclient/ConnectDevice.js
+++ b/widgets/xenclient/ConnectDevice.js
@@ -67,64 +67,7 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
             XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
         };
 
-        ///TEMPORARY FIX
-        ///ref OXT-116: https://openxt.atlassian.net/browse/OXT-116
-        ///Fix can be removed after rewrite/modification of vusb daemon fixes
-        ///race condition.
-
-        var complete = function(reassign) {
-            if(reassign){
-                for(var dev in vm.usbDevices){
-                    //vm.usbDevices is an object
-                    if (vm.usbDevices.hasOwnProperty(dev)){
-                        //newly reassigned usb device
-                        //is the device with the hightest ID
-                        if (dev > usb.dev_id){
-                            usb.dev_id = dev;
-                        }
-                    }
-                }
-            }
-            vm.assignUsbDevice(usb.dev_id, function() {
-                if (always) {
-                    vm.setUsbDeviceSticky(usb.dev_id, true, undefined, onError);
-                }
-            }, onError);
-        };
-
-        //We need to explicitly remove the USB during reassign
-        var removeThenComplete = function() {
-            //get vm the device is assigned to
-            assignedUuid = usb.assigned_uuid;
-            if (assignedUuid !== ""){
-                var curVM = XUICache.getVM(XUtils.uuidToPath(assignedUuid));
-                curVM.unassignUsbDevice(usb.dev_id, function(){
-                    //Success
-                    //Give some time for the device to be removed
-                    var interval = setInterval(function() {
-                        clearInterval(interval);
-                        complete(true);
-                    }, 2000);
-                }, function(error) {
-                    //error
-                    XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
-                });
-            }
-
-        };
-
-        if (usb.assignedToOtherVM()) {
-            // Confirm stealing device from another VM
-            var message = (usb.state == 2) ? this.USB_FORCE_REASSIGN : this.USB_REASSIGN;
-            XUICache.messageBox.showConfirmation(message, removeThenComplete);
-        } else {
-            complete();
-        }
-        ///END TEMPORARY FIX
-
-        ///ORIGINAL CODE, REPLACE TEMPORARY FIX WITH THIS
-        ///WHEN PERMENANT FIX COMPLETE
-        /*var complete = function() {
+        var complete = function() {
             vm.assignUsbDevice(usb.dev_id, function() {
                 if (always) {
                     vm.setUsbDeviceSticky(usb.dev_id, true, undefined, onError);
@@ -138,8 +81,7 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
             XUICache.messageBox.showConfirmation(message, complete);
         } else {
             complete();
-        }*/
-        ///END ORIGINAL CODE
+        }
 
         this.inherited(arguments);
     },

--- a/widgets/xenclient/templates/Devices.html
+++ b/widgets/xenclient/templates/Devices.html
@@ -57,9 +57,7 @@
                         <span templateType="citrix.common.ValidationTextBox" id="usb_name_%dev_id%" bind="name" maxLength="60" required="true" regExpObject="XenConstants.Regex.USB_NAME" invalidMessage="${NAME_VALERROR}"></span>
                     </td>
                     <td>
-                    <!-- PART OF TEMPORARY FIX, SEE _setUserChanged in ../Devices.js -->
-                        <select class="citrix" templateType="citrix.common.Select" id="usb_select_%dev_id%" optionsKey="usbVMList" bind="assigned_uuid" dojoAttachEvent="onChange: _onUSBAssignmentChange, onFocus: _setUserChanged, onBlur: _unsetUserChanged" ></select>
-                    <!-- END TEMPORARY FIX -->
+                        <select class="citrix" templateType="citrix.common.Select" id="usb_select_%dev_id%" optionsKey="usbVMList" bind="assigned_uuid" dojoAttachEvent="onChange: _onUSBChange"></select>
                     </td>
                     <td class="noWrap" colspan="2">
                         <span templateType="citrix.common.CheckBox" id="usb_check_%dev_id%" bind="getSticky" dojoAttachEvent="onChange: _onUSBChange"></span>


### PR DESCRIPTION
This removes the patches made in OXT-116 for usb race condition
and also addresses an issue where dropdowns selected in the
Devices window would not show their new setting after Save.

Signed off by: David Marsland
