### PR TITLE
OXT-448 - Correct issue with Devices USB dropdowns

### DIFF
--- a/dist/script/models/vmModel.js
+++ b/dist/script/models/vmModel.js
@@ -676,6 +676,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(!usb)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.state = 4;
         interfaces.usb.assign_device(usb.dev_id, self.uuid, onSuccess, failure);
     };
@@ -688,6 +692,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(!usb)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.state = 0;
         interfaces.usb.unassign_device(usb.dev_id, onSuccess, failure);
     };
@@ -700,6 +708,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(!usb)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.state = (self.getState() == XenConstants.VMStates.VM_RUNNING) ? 5 : 6;
         interfaces.usb.set_sticky(usb.dev_id, sticky ? 1 : 0, onSuccess, failure);
     };
@@ -712,6 +724,10 @@ XenClient.UI.VMModel = function(vm_path) {
             }
         }
         var usb = self.usbDevices[dev_id];
+        if(!usb)
+        {
+            usb = XUICache.Host.usbDevices[dev_id];
+        }
         usb.name = name;
         interfaces.usb.name_device(dev_id, name, onSuccess, failure);
     };
@@ -953,7 +969,7 @@ XenClient.UI.VMModel = function(vm_path) {
 
     this.deleteVisible = function() {
         return (self.policy_modify_vm && XUICache.Host.policy_delete_vm);
-    };    
+    };
 
     this.canModifyPCI = function() {
         return (self.policy_modify_vm && self.getState() == XenConstants.VMStates.VM_STOPPED);
@@ -1007,7 +1023,7 @@ XenClient.UI.VMModel = function(vm_path) {
     this.getTransferSpeed = function() {
         return 0;
     };
-    
+
     this.getAvailableDevices = function() {
         var devices = [];
         for (var id in self.usbDevices) {

--- a/widgets/xenclient/ConnectDevice.js
+++ b/widgets/xenclient/ConnectDevice.js
@@ -67,24 +67,7 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
             XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
         };
 
-        ///TEMPORARY FIX
-        ///ref OXT-116: https://openxt.atlassian.net/browse/OXT-116
-        ///Fix can be removed after rewrite/modification of vusb daemon fixes
-        ///race condition.
-
-        var complete = function(reassign) {
-            if(reassign){
-                for(var dev in vm.usbDevices){
-                    //vm.usbDevices is an object
-                    if (vm.usbDevices.hasOwnProperty(dev)){
-                        //newly reassigned usb device
-                        //is the device with the hightest ID
-                        if (dev > usb.dev_id){
-                            usb.dev_id = dev;
-                        }
-                    }
-                }
-            }
+        var complete = function() {
             vm.assignUsbDevice(usb.dev_id, function() {
                 if (always) {
                     vm.setUsbDeviceSticky(usb.dev_id, true, undefined, onError);
@@ -92,7 +75,7 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
             }, onError);
         };
 
-        //We need to explicitly remove the USB during reassign
+       //We need to explicitly remove the USB during reassign
         var removeThenComplete = function() {
             //get vm the device is assigned to
             assignedUuid = usb.assigned_uuid;
@@ -100,12 +83,20 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
                 var curVM = XUICache.getVM(XUtils.uuidToPath(assignedUuid));
                 curVM.unassignUsbDevice(usb.dev_id, function(){
                     //Success
-                    //Give some time for the device to be removed
-                    var interval = setInterval(function() {
+                    var interval = setInterval(function(){
                         clearInterval(interval);
-                        complete(true);
-                    }, 2000);
-                }, function(error) {
+                        XUICache.Host.refreshUsb(function(){
+                            var newID=0; // highest ID will be the new ID
+                            for(var i in XUICache.Host.usbDevices)
+                            {
+                                if(i>newID) newID=i;
+                            };
+                            usb.dev_id = newID;
+                            complete();
+                         })
+                        }, 2000);
+
+                    }, function(error) {
                     //error
                     XUICache.messageBox.showError(error, XenConstants.ToolstackCodes);
                 });
@@ -120,26 +111,6 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
         } else {
             complete();
         }
-        ///END TEMPORARY FIX
-
-        ///ORIGINAL CODE, REPLACE TEMPORARY FIX WITH THIS
-        ///WHEN PERMENANT FIX COMPLETE
-        /*var complete = function() {
-            vm.assignUsbDevice(usb.dev_id, function() {
-                if (always) {
-                    vm.setUsbDeviceSticky(usb.dev_id, true, undefined, onError);
-                }
-            }, onError);
-        };
-
-        if (usb.assignedToOtherVM()) {
-            // Confirm stealing device from another VM
-            var message = (usb.state == 2) ? this.USB_FORCE_REASSIGN : this.USB_REASSIGN;
-            XUICache.messageBox.showConfirmation(message, complete);
-        } else {
-            complete();
-        }*/
-        ///END ORIGINAL CODE
 
         this.inherited(arguments);
     },

--- a/widgets/xenclient/templates/Devices.html
+++ b/widgets/xenclient/templates/Devices.html
@@ -20,7 +20,7 @@
                     <td class="deviceRow">
                         <span templateType="citrix.common.BoundWidget" bind="id" binding="title">
                             <span templateType="citrix.common.BoundWidget" bind="name"></span>
-                        </span>                        
+                        </span>
                     </td>
                     <td>
                         <select class="citrix" templateType="citrix.common.Select" id="cd_select_%id%" optionsKey="cdVMList" bind="vm" dojoAttachEvent="onChange: _onCDChange"></select>
@@ -57,9 +57,7 @@
                         <span templateType="citrix.common.ValidationTextBox" id="usb_name_%dev_id%" bind="name" maxLength="60" required="true" regExpObject="XenConstants.Regex.USB_NAME" invalidMessage="${NAME_VALERROR}"></span>
                     </td>
                     <td>
-                    <!-- PART OF TEMPORARY FIX, SEE _setUserChanged in ../Devices.js -->
                         <select class="citrix" templateType="citrix.common.Select" id="usb_select_%dev_id%" optionsKey="usbVMList" bind="assigned_uuid" dojoAttachEvent="onChange: _onUSBAssignmentChange, onFocus: _setUserChanged, onBlur: _unsetUserChanged" ></select>
-                    <!-- END TEMPORARY FIX -->
                     </td>
                     <td class="noWrap" colspan="2">
                         <span templateType="citrix.common.CheckBox" id="usb_check_%dev_id%" bind="getSticky" dojoAttachEvent="onChange: _onUSBChange"></span>


### PR DESCRIPTION
This fix addresses an issue where dropdowns selected in the
Devices window would not show their new setting after Save.
It also fixes behavior seen where assigning a USB device from
one guestVM to another would return an error.

Signed off by: David Marsland
