### PR TITLE
Jethro USB fix

### DIFF
--- a/dist/script/models/usbServiceModel.js
+++ b/dist/script/models/usbServiceModel.js
@@ -17,9 +17,9 @@ XenClient.UI.USBServiceModel = function() {
 
     // Properties & Defaults
     var usbBusy = false;
-    this.__defineGetter__('isUsbBusy', function(){
+    this.isUsbBusy = function(){
         return usbBusy;
-    });
+    };
     
     // Services
     var services = {

--- a/widgets/xenclient/ConnectDevice.js
+++ b/widgets/xenclient/ConnectDevice.js
@@ -101,7 +101,7 @@ return declare("citrix.xenclient.ConnectDevice", [dialog, _boundContainerMixin],
     _messageHandler: function(message) {
         switch(message.type) {
             case XenConstants.TopicTypes.MODEL_USB_CHANGED:
-                if(!XUICache.USB.isUsbBusy){
+                if(!XUICache.USB.isUsbBusy()){
                     this._bindDijit();
                 }
                 break;

--- a/widgets/xenclient/Devices.js
+++ b/widgets/xenclient/Devices.js
@@ -241,12 +241,12 @@ return declare("citrix.xenclient.Devices", [dialog, _boundContainerMixin, _citri
         switch(message.type) {
             case XenConstants.TopicTypes.MODEL_USB_DEVICE_ADDED:
                 // don't update mid operation
-                if(!XUICache.USB.isUsbBusy){
+                if(!XUICache.USB.isUsbBusy()){
                     XUICache.Host.refreshUsb();
                 }
                 break;
             case XenConstants.TopicTypes.MODEL_USB_CHANGED: {
-                if(!XUICache.USB.isUsbBusy){
+                if(!XUICache.USB.isUsbBusy()){
                     this._bindDijit();
                 }
                 break;

--- a/widgets/xenclient/VMDetails.js
+++ b/widgets/xenclient/VMDetails.js
@@ -690,7 +690,7 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
                 break;
             }
             case XenConstants.TopicTypes.MODEL_USB_CHANGED: {
-                if (!XUICache.USB.isUsbBusy){
+                if (!XUICache.USB.isUsbBusy()){
                     this.bind(this.vm, this.usbTab.domNode);
                     this.bindTooltips();
                 }


### PR DESCRIPTION
No longer using **defineGetter** for USB stuff.  Seems like Midori
takes issue with that function when scheduling async evens in Jethro.

OXT-569

Signed-off-by: Andrew 'Doc' Docherty doc@coveycs.com
