### PR TITLE
[toolstack] Show message passed with IO error

### DIFF
--- a/widgets/xenclient/AlertDialog.js
+++ b/widgets/xenclient/AlertDialog.js
@@ -83,7 +83,11 @@ return declare("citrix.xenclient.AlertDialog", [dialog], {
             message = this._getErrorMessage(error, sourceHint);
         }
         xc_debug.log(message);
-        this._showDialog(message, args, onContinue);
+        if (error.code == 223) {
+            this._showDialog(error.message, args, onContinue);
+        } else {
+            this._showDialog(message, args, onContinue);
+        }
     },
 
     showWarning: function(message, onContinue, overrideArguments) {


### PR DESCRIPTION
  The toolstack defines a set of error codes that can be returned
  to the caller (in this case, the UI) on failure. A generic err
  is the "IO Error", and it is supposed to be accompanied by a
  description string. The UI currently does not show this message
  in the AlertDialog when it receives it. This commit ensures we display
  the IO error message in the Dialog when sent from the toolstack.
  This serves as both a bug fix and libxl enhancement.

  OXT-991

Signed-off-by: Chris Rogers <rogersc@ainfosec.com>