### PR TITLE
OXT-1265: rpcgen: Align with layer changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,9 @@ clean:
 	rm -rf dist/lib
 	rm -rf ${BUILT}
 
-${IDL_GENSRC_DIR}/%_client.js: ${IDL_DIR}/%.xml
+${IDL_GENSRC_DIR}/%_client.js: ${STAGING_IDLDATADIR}/%.xml
 	mkdir -p ${IDL_GENSRC_DIR}
-	${RPCGEN} --javascript --client -o ${IDL_GENSRC_DIR} $< || rm -f $@
+	${RPCGEN} --templates-dir=${STAGING_RPCGENDATADIR_NATIVE} --javascript --client -o ${IDL_GENSRC_DIR} $< || rm -f $@
 
 
 


### PR DESCRIPTION
Use appropriate variables to find IDL files and rpcgen templates.

OXT-1265

Depends on:
https://github.com/OpenXT/xenclient-oe/pull/825