### PR TITLE
OXT-1589: [ui] Disable sleep options

### DIFF
--- a/widgets/xenclient/templates/Menus.html
+++ b/widgets/xenclient/templates/Menus.html
@@ -6,7 +6,7 @@
             <div dojoType="citrix.common.Menu">
                 <div dojoType="citrix.common.MenuItem" dojoAttachEvent="onClick: onRestartClick">${RESTART_ACTION}</div>
                 <div dojoType="citrix.common.MenuItem" dojoAttachEvent="onClick: onRestartNoUpdateClick" dojoAttachPoint="restartNoUpdateNode">${RESTART_NO_UPDATE_ACTION}</div>
-                <div dojoType="citrix.common.MenuItem" dojoAttachEvent="onClick: onSleepClick">${SLEEP_ACTION}</div>
+                <div dojoType="citrix.common.MenuItem" disabled="true" dojoAttachEvent="onClick: onSleepClick">${SLEEP_ACTION}</div>
                 <div dojoType="citrix.common.MenuItem" dojoAttachEvent="onClick: onHibernateClick">${HIBERNATE_ACTION}</div>
                 <div dojoType="citrix.common.MenuItem" dojoAttachEvent="onClick: onLockClick" dojoAttachPoint="lockNode">${LOCK_SCREEN_ACTION}</div>
                 <div dojoType="citrix.common.MenuSeparator"></div>

--- a/widgets/xenclient/templates/Settings.html
+++ b/widgets/xenclient/templates/Settings.html
@@ -207,7 +207,7 @@
             <div dojoAttachPoint="powerTab" dojoType="citrix.common.ContentPane" title="${SYS_INFO_POWER_TITLE}">
                 <h1>${SYSTEM_SLEEP_HEADER}</h1>
                 <p>${SYSTEM_SLEEP_LABEL}</p>
-                <div dojoType="citrix.common.Timeout" smallDelta="1" largeDelta="5" max="60" name="idle_time_threshold" onLabel="${SYSTEM_SLEEP_ON_LABEL}" unitLabelPlural="${MINUTES}" unitLabelSingular="${MINUTE}" offLabel="${SYSTEM_SLEEP_OFF_LABEL}"></div>
+                <div dojoType="citrix.common.Timeout" smallDelta="1" largeDelta="5" max="60" name="idle_time_threshold" onLabel="${SYSTEM_SLEEP_ON_LABEL}" unitLabelPlural="${MINUTES}" unitLabelSingular="${MINUTE}" offLabel="${SYSTEM_SLEEP_OFF_LABEL}" disabled="true"></div>
                 <h1 class="laptop">${LID_CLOSE_LABEL}</h1>
                 <p class="laptop">${LID_CLOSE_AC_POWER_LABEL}</p>
                 <input class="laptop" id="acRadioSleep" type="radio" dojoType="citrix.common.RadioButton" value="sleep" name="ac_lid_close_action" />


### PR DESCRIPTION
  Host S3 support is blocked by several difficult to solve issues
  in both TBoot and Xen, let's disable able the clickable options
  to perform sleep.

  Using the commandline toolstack, we can initiate a host sleep
  for debugging or testing if desired.

  OXT-1589

Signed-off-by: Chris <rogersc@ainfosec.com>