### PR TITLE
vglass: remove HDX UI elements and surfman RPC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,6 @@ IDLS=	xenmgr.xml \
 	input_daemon.xml \
 	ctxusb_daemon.xml \
 	xenvm.xml \
-	surfman.xml \
 	updatemgr.xml \
 	network.xml \
 	network_daemon.xml \

--- a/dist/auth.html
+++ b/dist/auth.html
@@ -39,7 +39,6 @@
     <script type="text/javascript" src="script/services/input_daemon_client.js"></script>
     <script type="text/javascript" src="script/services/xenmgr_client.js"></script>
     <script type="text/javascript" src="script/services/xenmgr_host_client.js"></script>
-    <script type="text/javascript" src="script/services/surfman_client.js"></script>
     <script type="text/javascript" src="script/services/network_daemon_client.js"></script>
     <script type="text/javascript" src="script/services/xcpmd_client.js"></script>
 

--- a/dist/create_report.html
+++ b/dist/create_report.html
@@ -39,7 +39,6 @@
     <script type="text/javascript" src="script/services/input_daemon_client.js"></script>
     <script type="text/javascript" src="script/services/xenmgr_client.js"></script>
     <script type="text/javascript" src="script/services/xenmgr_host_client.js"></script>
-    <script type="text/javascript" src="script/services/surfman_client.js"></script>
     <script type="text/javascript" src="script/services/network_daemon_client.js"></script>
     <script type="text/javascript" src="script/services/xcpmd_client.js"></script>
 

--- a/dist/index.html
+++ b/dist/index.html
@@ -46,7 +46,6 @@
     <script type="text/javascript" src="script/services/xenmgr_host_client.js"></script>
     <script type="text/javascript" src="script/services/xenmgr_vm_client.js"></script>
     <script type="text/javascript" src="script/services/xenvm_client.js"></script>
-    <script type="text/javascript" src="script/services/surfman_client.js"></script>
     <script type="text/javascript" src="script/services/updatemgr_client.js"></script>
     <script type="text/javascript" src="script/services/network_daemon_client.js"></script>
     <script type="text/javascript" src="script/services/network_domain_client.js"></script>

--- a/dist/script/models/hostModel.js
+++ b/dist/script/models/hostModel.js
@@ -101,7 +101,6 @@ XenClient.UI.HostModel = function() {
         manager:    new XenClient.DBus.XenmgrClient("com.citrix.xenclient.xenmgr", "/"),
         host:       new XenClient.DBus.XenmgrHostClient("com.citrix.xenclient.xenmgr", "/host"),
         input:      new XenClient.DBus.InputDaemonClient("com.citrix.xenclient.input", "/"),
-        surfman:    new XenClient.DBus.SurfmanClient("com.citrix.xenclient.surfman", "/"),
         network:    new XenClient.DBus.NetworkDaemonClient("com.citrix.xenclient.networkdaemon", "/"),
         xcpmd:      new XenClient.DBus.XcpmdClient("com.citrix.xenclient.xcpmd", "/")
     };
@@ -116,7 +115,6 @@ XenClient.UI.HostModel = function() {
         power:      services.host.com.citrix.xenclient.xenmgr.powersettings,
         installer:  services.host.com.citrix.xenclient.xenmgr.installer,
         input:      services.input.com.citrix.xenclient.input,
-        surfman:    services.surfman.com.citrix.xenclient.surfman,
         network:    services.network.com.citrix.xenclient.networkdaemon,
         xcpmd:      services.xcpmd.com.citrix.xenclient.xcpmd
         // the usb interface is now used through XUICache.USB
@@ -335,8 +333,6 @@ XenClient.UI.HostModel = function() {
     this.authSetContextFlags = interfaces.input.auth_set_context_flags;
     this.createVMWithUI = interfaces.manager.create_vm_with_ui;
     this.createVhd = interfaces.manager.create_vhd;
-    this.increaseBrightness = interfaces.surfman.increase_brightness;
-    this.decreaseBrightness = interfaces.surfman.decrease_brightness;
     this.listBatteries = interfaces.xcpmd.batteries_present; 
     this.listPowerDevices = interfaces.xcpmd.battery_is_present;
     this.listNDVMs = interfaces.network.list_backends;

--- a/dist/script/models/hostModel.js
+++ b/dist/script/models/hostModel.js
@@ -67,7 +67,6 @@ XenClient.UI.HostModel = function() {
     this.safe_graphics = false;
     this.measured_boot_enabled = true;
     this.measured_boot_successful = false;
-    this.drm_enabled = false;
     this.licensed = true;
     this.available_isos = [];
     this.available_gpus = [];
@@ -188,7 +187,6 @@ XenClient.UI.HostModel = function() {
         ["wallpaper",                           interfaces.ui],
         ["pointer_trail_timeout",               interfaces.ui],
         ["show_msg_measured_boot",              interfaces.ui, "show-mboot-warning"],
-        ["drm_enabled",                         interfaces.ui, "drm-graphics"],
         ["ac_lid_close_action",                 interfaces.power.get_ac_lid_close_action,       interfaces.power.set_ac_lid_close_action],
         ["battery_lid_close_action",            interfaces.power.get_battery_lid_close_action,  interfaces.power.set_battery_lid_close_action],
         ["auth_on_boot",                        interfaces.input.get_auth_on_boot,              interfaces.input.set_auth_on_boot],

--- a/dist/script/models/vmModel.js
+++ b/dist/script/models/vmModel.js
@@ -561,12 +561,7 @@ XenClient.UI.VMModel = function(vm_path) {
             if (self.startMultipleAction && !self.tools_installed && XUICache.runningVMCount() >= 2) {
                 fn = fn.decorate(self.startMultipleAction);
             }
-            // Warn about 3d graphics
-            if (self.isHdxEnabled() && self.startThreedAction) {
-                self.startThreedAction(fn);
-            } else {
-                fn();
-            }
+            fn();
         }
     };
 
@@ -710,14 +705,6 @@ XenClient.UI.VMModel = function(vm_path) {
         repository.load("download_progress", function() {
             self.publish(XenConstants.TopicTypes.MODEL_TRANSFER_CHANGED);
         });
-    };
-
-    this.isHdxEnabled = function() {
-        return (self.gpu != "");
-    };
-
-    this.isHdxRunning = function() {
-        return (self.isHdxEnabled() && self.isRunning());
     };
 
     this.isPublishEnabled = function() {

--- a/widgets/xenclient/Settings.js
+++ b/widgets/xenclient/Settings.js
@@ -80,10 +80,6 @@ return declare("citrix.xenclient.Settings", [dialog, _boundContainerMixin, _citr
                 // A guest VM is running and we have changed an audio setting
                 XUICache.messageBox.showWarning(this.AUDIO_CHANGED);
             }
-
-            if (typeof(values.drm_enabled) !== "undefined") {
-                XUICache.messageBox.showInformation(this.DRM_CHANGED);
-            }
         }));
 	},
 

--- a/widgets/xenclient/VMDetails.js
+++ b/widgets/xenclient/VMDetails.js
@@ -499,10 +499,10 @@ return declare("citrix.xenclient.VMDetails", [dialog, _boundContainerMixin, _edi
         this.isos.set("map", isoMap);
 
         var gpuMap = {};
-        var discrete_gpus = XUICache.Host.available_gpus.slice(1);
+        var discrete_gpus = XUICache.Host.available_gpus
         gpuMap[this.DISABLED] = "";
         dojo.forEach(discrete_gpus, function(gpu) {
-            gpuMap[(discrete_gpus.length == 1) ? this.ENABLED : gpu.name] = gpu.addr;
+            gpuMap[gpu.name] = gpu.addr;
         }, this);
 
         this.threed.set("map", gpuMap);

--- a/widgets/xenclient/nls/Settings.js
+++ b/widgets/xenclient/nls/Settings.js
@@ -68,9 +68,6 @@
     SCREEN_LOCK_OFF_LABEL: "Do not lock the screen",
     SCREEN_LOCK_HELP: "To enable screen lock settings please set a local password.",
     PLUGINS_HEADER: "Display Plugins",
-    ENABLE_DRM: "Use DRM Plugin:",
-    DRM_ENABLED: "Always",
-    DRM_DISABLED: "Haswell platform and newer",
     STATUS_REPORT: "Creating a status report will collect diagnostic information from this device and package it into a single file.<br/><br/>This can be done at any time by pressing CTRL+ALT+R",
     CREATE_STATUS_REPORT: "Create Status Report",
     STATUS_SERVER_HEADER: "Report Download",
@@ -96,7 +93,6 @@
     AUDIO_MASK_SW: "{0}",
     AUDIO_MASK_EN: "{0}",
     AUDIO_CHANGED: "Audio changes will not apply to running VMs until they are restarted.",
-    DRM_CHANGED: "DRM plugin changes will not take effect until the host has been rebooted.\n\nIf 'Measured Launch' is enabled, this will also require a reseal.",
     LANGUAGE_WARNING: "The language setting has been changed and the user interface needs to restart.",
     // Other
     AUTH_MANAGED_TEXT: "Please use your Synchronizer credentials to log in.",

--- a/widgets/xenclient/templates/Settings.html
+++ b/widgets/xenclient/templates/Settings.html
@@ -265,13 +265,6 @@
                 <p class="auth local">${CHANGE_PASSWORD_HELP}</p>
                 <button class="actionButton auth local" dojoType="citrix.common.Button" dojoAttachEvent="onClick: changePassword">${CHANGE_PASSWORD_ACTION}</button>
             </div>
-            <div dojoType="citrix.common.ContentPane" title="${SYS_INFO_ADVANCED}">
-                <h1>${PLUGINS_HEADER}</h1>
-                <div class="citrixTabPaneField">
-                    <label dojoType="citrix.common.Label" for="drm_enabled">${ENABLE_DRM}</label>
-                    <span class="citrix value" dojoType="citrix.common.Select" options="[{'label': '${DRM_ENABLED}', 'value': true}, {'label': '${DRM_DISABLED}', 'value': false}]" name="drm_enabled"></span>
-                </div>
-            </div>
         </div>
     </div>
     <div dojoAttachPoint="footerNode" class="citrixDialogFooterContent">

--- a/widgets/xenclient/templates/VM.html
+++ b/widgets/xenclient/templates/VM.html
@@ -12,7 +12,6 @@
                 <div class="vmSpinner" dojoType="citrix.common.BoundWidget" binding="display" name="isBusy"></div>
                 <div class="badgeContainer">
                     <span dojoType="citrix.common.BoundWidget" binding="display" name="isManaged" class="badgeIcon dark badgeIconManaged" title="${MANAGED_ENABLED}" position="above"></span>
-                    <span dojoType="citrix.common.BoundWidget" binding="display" name="isHdxRunning" class="badgeIcon dark badgeIconThreed" title="${THREED_GRAPHICS_ENABLED}" position="above"></span>
                     <span dojoType="citrix.common.BoundWidget" binding="display" name="native_experience" class="dark badgeIcon badgeIconNative" title="${NATIVE_MODE_ENABLED}" position="above"></span>
                     <span dojoType="citrix.common.BoundWidget" binding="display" name="allDisksReset" class="badgeIcon dark badgeIconDiskReset" title="${DISK_RESET_ENABLED}" position="above"></span>
                     <span dojoType="citrix.common.BoundWidget" binding="display" name="allDisksEncrypted" class="badgeIcon dark badgeIconEncrypted" title="${ENCRYPTION_ENABLED}" position="above"></span>

--- a/widgets/xenclient/templates/VMDetails.html
+++ b/widgets/xenclient/templates/VMDetails.html
@@ -423,7 +423,6 @@
     <div dojoAttachPoint="footerNode" class="citrixDialogFooterContent">
         <span class="citrixDialogFooter">
             <span dojoType="citrix.common.BoundWidget" binding="display" name="isManaged" class="citrixDialogFooterItem badgeIcon badgeIconManaged" title="${MANAGED_ENABLED}" position="above"></span>
-            <span dojoType="citrix.common.BoundWidget" binding="display" name="isHdxRunning" class="citrixDialogFooterItem badgeIcon badgeIconThreed" title="${THREED_GRAPHICS_ENABLED}" position="above"></span>
             <span dojoType="citrix.common.BoundWidget" binding="display" name="native_experience" class="citrixDialogFooterItem badgeIcon badgeIconNative" title="${NATIVE_MODE_ENABLED}" position="above"></span>
             <span dojoType="citrix.common.BoundWidget" binding="display" name="allDisksReset" class="citrixDialogFooterItem badgeIcon badgeIconDiskReset" title="${DISK_RESET_ENABLED}" position="above"></span>
             <span dojoType="citrix.common.BoundWidget" binding="display" name="allDisksEncrypted" class="citrixDialogFooterItem badgeIcon badgeIconEncrypted" title="${ENCRYPTION_ENABLED}" position="above"></span>


### PR DESCRIPTION
The UI had some Surfman specific RPC handling with Surfman (brightness and HDX reports). These can be retired, HDX was no longer implemented by Surfman, this is not related to discret GPU passthrough.